### PR TITLE
Update de_uploadimages.js

### DIFF
--- a/public/js/de_uploadimages.js
+++ b/public/js/de_uploadimages.js
@@ -1,6 +1,6 @@
 
  Dropzone.autoDiscover = false;
-            var acceptedFileType = ".jpg, .png, .tif, .psd";
+            var acceptedFileType = ".jpg, .png, .tiff, .psd";
             var imageCount = 0;
             var imageUploadInfos =[];
             $(document).ready(function(){


### PR DESCRIPTION
Los diseñadores deben subir en formato .tiff ya que estos tienen varias capas.